### PR TITLE
9 Add functionality to create new poem

### DIFF
--- a/app/controllers/admin/poems_controller.rb
+++ b/app/controllers/admin/poems_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PoemsController < ApplicationController
   def index
-    # instantiate poem for use in new poem form (#create action)
+    # instantiate poem for use in "Create poem" form (#create action)
     @poem = Poem.new
 
     @poems = Poem.order(:id)
@@ -16,7 +16,6 @@ class Admin::PoemsController < ApplicationController
         'Poem creation failed.'
       end
 
-    # after submitting new poem, redirect back to poems index
     redirect_to(admin_poems_path)
   end
 

--- a/app/controllers/admin/poems_controller.rb
+++ b/app/controllers/admin/poems_controller.rb
@@ -1,5 +1,25 @@
 class Admin::PoemsController < ApplicationController
   def index
+    # instantiate poem for use in new poem form (#create action)
+    @poem = Poem.new
+
     @poems = Poem.order(:id)
+  end
+
+  def create
+    @poem = Poem.new(poem_params)
+    @poem.save
+
+    # after submitting new poem, redirect back to poems index
+    redirect_to(admin_poems_path)
+  end
+
+  private
+
+  # Whitelist the poem parameters used to define a poem. Otherwise, an attempted
+  # assignemnt will throw ActiveModel::ForbiddenAttributesError.
+  def poem_params
+    params.require(:poem).permit(:greek_title, :english_title, :greek_body, :english_body,
+      :published)
   end
 end

--- a/app/controllers/admin/poems_controller.rb
+++ b/app/controllers/admin/poems_controller.rb
@@ -8,7 +8,13 @@ class Admin::PoemsController < ApplicationController
 
   def create
     @poem = Poem.new(poem_params)
-    @poem.save
+
+    flash[:notice] =
+      if @poem.save
+        'Poem successfully created!'
+      else
+        'Poem creation failed.'
+      end
 
     # after submitting new poem, redirect back to poems index
     redirect_to(admin_poems_path)

--- a/app/views/admin/poems/index.html.haml
+++ b/app/views/admin/poems/index.html.haml
@@ -1,4 +1,7 @@
-%h1 poems
+- if flash[:notice]
+  %p
+    = flash[:notice]
+%h1 Poems
 %ul
   - @poems.each do |poem|
     %li

--- a/app/views/admin/poems/index.html.haml
+++ b/app/views/admin/poems/index.html.haml
@@ -3,3 +3,30 @@
   - @poems.each do |poem|
     %li
       = "#{poem.greek_title} (#{poem.english_title})"
+
+%h1 Add poem
+= form_for [:admin, @poem] do |f|
+  = f.label :greek_title
+  %br
+  = f.text_field :greek_title
+  %br
+
+  = f.label :english_title
+  %br
+  = f.text_field :english_title
+  %br
+
+  = f.label :greek_body
+  %br
+  = f.text_area :greek_body
+  %br
+
+  = f.label :english_body
+  %br
+  = f.text_area :english_body
+  %br
+
+  = f.check_box :published
+  = f.label :published
+  %br
+  = f.submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   namespace :admin do
     get '/poems', to: 'poems#index'
+    post '/poems', to: 'poems#create'
   end
 end

--- a/db/migrate/20180217030453_create_poems.rb
+++ b/db/migrate/20180217030453_create_poems.rb
@@ -1,8 +1,8 @@
 class CreatePoems < ActiveRecord::Migration[5.1]
   def change
     create_table :poems do |t|
-      t.string :greek_title, default: 'Untitled', null: false
-      t.string :english_title, default: 'Χωρίς τίτλο', null: false
+      t.string :greek_title, default: 'Χωρίς τίτλο', null: false
+      t.string :english_title, default: 'Untitled', null: false
       t.text :greek_body
       t.text :english_body
       t.boolean :published, default: false, index: true, null: false

--- a/spec/features/admin/create_poem_spec.rb
+++ b/spec/features/admin/create_poem_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+feature 'Admin creates a new poem' do
+  scenario 'they see the poem on the index' do
+    visit '/admin/poems'
+
+    fill_in 'greek_title', with: 'Titlos Alpha'
+    fill_in 'english_title', with: 'Title A'
+    fill_in 'greek_body', with: 'A Greek body is a wonderful thing.'
+    fill_in 'english_body', with: 'An English body is less sought after.'
+    page.check('publish')
+    click_button 'create_poem'
+
+    expect(page).to have_selector('li', text: 'Titlos Alpha (Title A)')
+  end
+end

--- a/spec/features/admin/create_poem_spec.rb
+++ b/spec/features/admin/create_poem_spec.rb
@@ -4,12 +4,12 @@ feature 'Admin creates a new poem' do
   scenario 'they see the poem on the index' do
     visit '/admin/poems'
 
-    fill_in 'greek_title', with: 'Titlos Alpha'
-    fill_in 'english_title', with: 'Title A'
-    fill_in 'greek_body', with: 'A Greek body is a wonderful thing.'
-    fill_in 'english_body', with: 'An English body is less sought after.'
-    page.check('publish')
-    click_button 'create_poem'
+    fill_in 'poem_greek_title', with: 'Titlos Alpha'
+    fill_in 'poem_english_title', with: 'Title A'
+    fill_in 'poem_greek_body', with: 'A Greek body is a wonderful thing.'
+    fill_in 'poem_english_body', with: 'An English body is less sought after.'
+    page.check('poem_published')
+    click_button 'Create Poem'
 
     expect(page).to have_selector('li', text: 'Titlos Alpha (Title A)')
   end

--- a/spec/features/admin/create_poem_spec.rb
+++ b/spec/features/admin/create_poem_spec.rb
@@ -12,5 +12,6 @@ feature 'Admin creates a new poem' do
     click_button 'Create Poem'
 
     expect(page).to have_selector('li', text: 'Titlos Alpha (Title A)')
+    expect(page).to have_selector('p', text: 'Poem successfully created!')
   end
 end


### PR DESCRIPTION
Adds admin interface for adding a poem to the database. Also corrects a typo in the create poems migration where the default Greek and English poem titles were switched.

* Resolves #9.